### PR TITLE
Support for version constraint wildcards

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,8 +226,6 @@ Supported operators:
     - e.g. `~1.2.3` := `>=1.2.3, <1.3.0`
 - `~>` : you accept any version equal to or greater than in the last digit
     - e.g. `~>3.0.3` := `>= 3.0.3, < 3.1`
-    
-**NOTE** : `version` package doesn't support wildcards such as `x`, `X`, and `*`.
 
 #### Pre-release
 Unlike the `semver` package, `version` package always includes pre-release versions even with no pre-releases constraint.

--- a/pkg/part/list.go
+++ b/pkg/part/list.go
@@ -49,12 +49,6 @@ func (parts Parts) Padding(size int, padding Part) Parts {
 }
 
 func (parts Parts) Compare(other Part) int {
-	if other == nil {
-		return 1
-	} else if other.IsAny() {
-		return 0
-	}
-
 	var o Parts
 	switch t := other.(type) {
 	case InfinityType:
@@ -64,6 +58,11 @@ func (parts Parts) Compare(other Part) int {
 	case Parts:
 		o = t
 	default:
+		if other == nil {
+			return 1
+		} else if other.IsAny() {
+			return 0
+		}
 		return -1
 	}
 

--- a/pkg/version/constraint_test.go
+++ b/pkg/version/constraint_test.go
@@ -67,12 +67,17 @@ func TestVersion_Check(t *testing.T) {
 		{"2.1", "2.2.1", false},
 		{"4.1", "4.1.0", true},
 		{"1.0", "1.0.0", true},
+		{"1.x", "1.2.3", true},
+		{"4.1.x", "4.1.3", true},
 
 		// Not equal
 		{"!=4.1.0", "4.1.0", false},
 		{"!=4.1.0", "4.1.1", true},
 		{"!=4.1", "5.1.0-alpha.1", true},
 		{"!=4.1-alpha", "4.1.0", true},
+		{"!=4.x", "5.1.0", true},
+		{"!=4.1.x", "4.2.0", true},
+		{"!=4.2.x", "4.2.3", false},
 
 		// Less than
 		{"<0.0.5", "0.1.0", false},
@@ -86,6 +91,10 @@ func TestVersion_Check(t *testing.T) {
 		{"<1.1", "0.1.0", true},
 		{"<1.1", "1.1.0", false},
 		{"<1.1", "1.1.1", false},
+		{"<1.x", "1.1.1", false},
+		{"<2.x", "1.1.1", true},
+		{"<1.1.x", "1.2.1", false},
+		{"<1.2.x", "1.1.1", true},
 
 		// Less than or equal
 		{"<=0.2.3", "1.2.3", false},
@@ -98,6 +107,9 @@ func TestVersion_Check(t *testing.T) {
 		{"<=1.1", "0.1.0", true},
 		{"<=1.1", "1.1.0", true},
 		{"<=1.1", "1.1.1", false}, // different
+		{"<=1.x", "1.1.1", true},
+		{"<=2.x", "3.0.0", false},
+		{"<=1.1.x", "1.2.1", false},
 
 		// Greater than
 		{">5.0.0", "4.1.0", false},
@@ -120,6 +132,8 @@ func TestVersion_Check(t *testing.T) {
 		{">11.1", "11.1.0", false},
 		{">11.1", "11.1.1", true}, // different
 		{">11.1", "11.2.1", true},
+		{">11.x", "11.2.1", false},
+		{">11.1.x", "11.2.1", true},
 
 		// Greater than or equal
 		{">=11.1.3", "11.1.2", false},
@@ -146,6 +160,8 @@ func TestVersion_Check(t *testing.T) {
 		{">=1.1", "1.1.0", true},
 		{">=1.1", "0.0.9", false},
 		{">=0", "0.0.0", true},
+		{">=11.x", "11.1.2", true},
+		{">=11.1.x", "11.1.2", true},
 
 		// Pessimistic
 		{"~> 1.0", "2.0", false},
@@ -170,6 +186,10 @@ func TestVersion_Check(t *testing.T) {
 		{"~> 2.1.0-a", "2.1.0", true},
 		{"~> 2.1.0-a", "2.1.0-beta", true},
 		{"~> 2.1.0-a", "2.2.0-alpha", true},
+		{"~> 1.x", "2.0", false},
+		{"~> 1.x", "1.1", true},
+		{"~> 1.0.x", "1.2.3", true},
+		{"~> 1.0.x", "1.0.7", true},
 
 		// Tilde
 		{"~1.2.3", "1.2.4", true},
@@ -184,6 +204,8 @@ func TestVersion_Check(t *testing.T) {
 		{"~1.2.3-beta.2", "1.2.3-beta.4", true},
 		{"~1.2.3-beta.2", "1.2.4-beta.2", true},
 		{"~1.2.3-beta.2", "1.3.4-beta.2", false},
+		{"~1.x", "2.1.1", false},
+		{"~1.x", "1.3.5", true},
 
 		// Caret
 		{"^1.2.3", "1.8.9", true},
@@ -214,6 +236,28 @@ func TestVersion_Check(t *testing.T) {
 		{"^0.2.3-beta.2", "0.2.4-beta.2", true},
 		{"^0.2.3-beta.2", "0.3.4-beta.2", false},
 		{"^0.2.3-beta.2", "0.2.3-beta.2", true},
+		{"^1.x", "1.1.1", true},
+		{"^2.x", "1.1.1", false},
+
+		// Wildcards
+		{"", "1", true},
+		{"", "4.5.6", true},
+		{"", "1.2.3-alpha", false},
+		{"*", "1", true},
+		{"*", "4.5.6", true},
+		{"*", "1.2.3-alpha", false},
+		{"*-alpha", "1.2.3-alpha", true},
+		{"2.*", "1", false},
+		{"2.*", "3.4.5", false},
+		{"2.*", "2.1.1", true},
+		{"2.1.*", "2.1.1", true},
+		{"2.1.*", "2.2.1", false},
+
+		// Ranges
+		{"1.1 - 2", "1.1.1", true},
+		{"1.1 - 3", "3.4.5", true},
+		{"1.1 - 3", "4.3.2", false},
+		{"1.5.0 - 4", "3.7.0", true},
 
 		// More than 3 numbers
 		{"< 1.0.0.1 || = 2.0.1.2.3", "2.0", false},


### PR DESCRIPTION
I discovered you started a library after commenting on my PR at https://github.com/hashicorp/go-version/pull/49. I've written this PR which adds support for version wildcards and passes all https://github.com/Masterminds/semver test cases.

This also addresses a few issues:
- Repeated calls to Constraints `Check` will mutate the object in `PessimisticBump`, `TildeBump` and `CaretBump`
- Adding a prerelease check for all constraint functions
- Empty string is treated the same as wildcards