### PR TITLE
Fix parsing and comparing versions with build information

### DIFF
--- a/pkg/version/constraint_test.go
+++ b/pkg/version/constraint_test.go
@@ -237,6 +237,12 @@ func TestVersion_Check(t *testing.T) {
 		{"> 1.0 < 1.2 || >3.0, <4.0", "4.2", false},
 		{"^0.2 || ^1", "1.8.0", true},
 		{"^0.2, ^1", "1.8.0", false},
+
+		// Build identifiers
+		{">= 1.0.0, < 1.2.0+security-01", "1.0.0", true},
+		{">= 1.0.0, < 1.2.0+security-01", "1.2.0", false},
+		{">= 1.0.0, <= 1.2.0+security-01", "1.2.0", true},
+		{">= 1.0.0, < 1.2.0+security-01", "1.3.0", false},
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s %s", tt.version, tt.constraint), func(t *testing.T) {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -21,8 +21,7 @@ const (
 	// The raw regular expression string used for testing the validity of a version.
 	regex = `v?([0-9]+(\.[0-9]+)*)` +
 		`(-([0-9]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)|(-?([A-Za-z\-~]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)))?` +
-		`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
-		`?`
+		`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?`
 )
 
 // Version represents a single version.


### PR DESCRIPTION
This regex is pretty complex and I don't grok it all.  I found that removing the last `?` allows expected results when build information is present, and does not break any existing scenarios covered by unit tests.
With 2 `?`'s, regex101 describes this as
> ?? matches the previous token between zero and one times, as few times as possible, expanding as needed (lazy)

vs with 1 `?`: 
> ? matches the previous token between zero and one times, as many times as possible, giving back as needed (greedy)

Additionally I added multiple test cases to validate build information being handled as expected.  Per the semver spec, "Build metadata MUST be ignored when determining version precedence" - added test cases verify that it is in fact ignored as expected.

fixes #7